### PR TITLE
Support scopes defined both in strategy constructor and authenticate call.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -216,7 +216,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     var params = this.authorizationParams(options);
     params.response_type = 'code';
     if (callbackURL) { params.redirect_uri = callbackURL; }
-    var scope = options.scope || this._scope;
+
+    var scope;
+    if (this._scope && options.scope) {
+      scope = [].concat(options.scope).concat(this._scope);
+    } else {
+      scope = this._scope || options.scope;
+    }
+
     if (scope) {
       if (Array.isArray(scope)) { scope = scope.join(this._scopeSeparator); }
       params.scope = scope;

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -270,6 +270,35 @@ describe('OAuth2Strategy', function() {
         expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=permission_1%2Cpermission_2&client_id=ABC123');
       });
     }); // that redirects to service provider with scope option as array using non-standard separator
+
+    describe('that redirects to service provider with scope option from constructor', function() {
+      var strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        scope: 'profile',
+      },
+      function(accessToken, refreshToken, profile, done) {});
+
+      var url;
+
+      before(function(done) {
+        chai.passport.use(strategy)
+          .redirect(function(u) {
+            url = u;
+            done();
+          })
+          .req(function(req) {
+          })
+          .authenticate({ scope: 'email' });
+      });
+
+      it('should be redirected', function() {
+        expect(url).to.equal('https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&scope=email%20profile&client_id=ABC123');
+      });
+    }); // that redirects to service provider with scope option from constructor
     
     describe('that redirects to service provider with state option', function() {
       var strategy = new OAuth2Strategy({


### PR DESCRIPTION
As I mentioned in `jaredhanson/passport-oauth2`, I'm adding this feature to cover cases in which strategy users want to have default scope set up in their Strategy constructor (maybe something like `profile`) and then customize other scopes based on user selection. 

Right now, the scope that comes in the `options` object from `authenticate()` overrides whatever was set up in the constructor. 

Tested it in the following scenarios:
- Scopes defined both in strategy constructor and authenticate `options` obj
- Scopes defined only in strategy constructor
- Scopes defined only in authenticate options obj
- No scopes are defined