### PR TITLE
Add option to pass user id_token to the overloaded userProfile in strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ OPTIONAL<br>
 `{ customHeaders: Object }`<br>
 Custom headers you can pass along with the authorization request.
 
+#### parseIdToken
+OPTIONAL<br>
+`{ parseIdToken: boolean }`<br>
+When set to `true`, the id token is used to construct the user profile instead of the access token (if the authentication response also includes an id token).
+
 #### passReqToCallback
 OPTIONAL<br>
 `{ passReqToCallback: boolean }`<br>

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -108,6 +108,7 @@ function OAuth2Strategy(options, verify) {
   }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;
+  this._loadUserProfileFromIdToken = options.parseIdToken;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
 }
 
@@ -148,7 +149,7 @@ OAuth2Strategy.prototype.authenticate = function authenticate(req, options) {
           );
         }
 
-        self._loadUserProfile(accessToken, (profileErr, profile) => {
+        self._loadUserProfile(accessToken, tokenParams, (profileErr, profile) => {
           if (profileErr) { return self.error(profileErr); }
 
           function verified(verifiedErr, user, info) {
@@ -348,13 +349,17 @@ OAuth2Strategy.prototype.parseErrorResponse = function parseErrorResponse(body) 
  * Load user profile, contingent upon options.
  *
  * @param {String} accessToken
+ * @param {Object} params
  * @param {Function} done
  * @api private
  */
-OAuth2Strategy.prototype._loadUserProfile = function _loadUserProfile(accessToken, done) {
+OAuth2Strategy.prototype._loadUserProfile = function _loadUserProfile(accessToken, params, done) {
   const self = this;
 
   function loadIt() {
+    if (self._loadUserProfileFromIdToken && params.id_token) {
+      return self.userProfile(params.id_token, done);
+    }
     return self.userProfile(accessToken, done);
   }
   function skipIt() {

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -892,6 +892,142 @@ describe('OAuth2Strategy', () => {
       });
     }); // that was approved using verify callback that accepts params, in passReqToCallback mode
 
+    describe('that was approved using verify callback, in parseIdToken mode', () => {
+      const strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        parseIdToken: true
+      },
+      (accessToken, refreshToken, profile, done) => {
+        if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
+        if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
+        if (typeof profile !== 'object') { return done(new Error('incorrect profile argument')); }
+        if (Object.keys(profile).length !== 0) { return done(new Error('incorrect profile argument')); }
+
+        return done(null, { id: '1234' }, { message: 'Hello' });
+      });
+
+      strategy._oauth2.getOAuthAccessToken = function getOAuthAccessToken(code, options, callback) {
+        if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
+        if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
+        if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
+
+        return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', { token_type: 'example', expires_in: 3600, id_token: '9mlyl1BefQQYaYS6WCSbIA' });
+      };
+
+      strategy.userProfile = function userProfile(idToken, callback) {
+        if (idToken !== '9mlyl1BefQQYaYS6WCSbIA') {
+          return callback(new Error('Incorrect idToken'));
+        }
+
+        return callback(null, {});
+      };
+
+
+      let user;
+
+
+      let info;
+
+      before((done) => {
+        chai.passport.use(strategy)
+          .success((u, i) => {
+            user = u;
+            info = i;
+            done();
+          })
+          .req((req) => {
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', () => {
+        expect(user).to.be.an('object');
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', () => {
+        expect(info).to.be.an('object');
+        expect(info.message).to.equal('Hello');
+      });
+    }); // that was approved using verify callback, in passReqToCallback mode
+
+    describe('that was approved using verify callback that accepts params, in parseIdToken mode', () => {
+      const strategy = new OAuth2Strategy({
+        authorizationURL: 'https://www.example.com/oauth2/authorize',
+        tokenURL: 'https://www.example.com/oauth2/token',
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        callbackURL: 'https://www.example.net/auth/example/callback',
+        parseIdToken: true
+      },
+      (accessToken, refreshToken, params, profile, done) => {
+        if (accessToken !== '2YotnFZFEjr1zCsicMWpAA') { return done(new Error('incorrect accessToken argument')); }
+        if (refreshToken !== 'tGzv3JOkF0XG5Qx2TlKWIA') { return done(new Error('incorrect refreshToken argument')); }
+        if (params.example_parameter !== 'example_value') { return done(new Error('incorrect params argument')); }
+        if (typeof profile !== 'object') { return done(new Error('incorrect profile argument')); }
+        if (Object.keys(profile).length !== 0) { return done(new Error('incorrect profile argument')); }
+
+        return done(null, { id: '1234' }, { message: 'Hello' });
+      });
+
+      strategy._oauth2.getOAuthAccessToken = function getOAuthAccessToken(code, options, callback) {
+        if (code !== 'SplxlOBeZQQYbYS6WxSbIA') { return callback(new Error('incorrect code argument')); }
+        if (options.grant_type !== 'authorization_code') { return callback(new Error('incorrect options.grant_type argument')); }
+        if (options.redirect_uri !== 'https://www.example.net/auth/example/callback') { return callback(new Error('incorrect options.redirect_uri argument')); }
+
+        return callback(null, '2YotnFZFEjr1zCsicMWpAA', 'tGzv3JOkF0XG5Qx2TlKWIA', {
+          token_type: 'example',
+          expires_in: 3600,
+          example_parameter: 'example_value',
+          id_token: '9mlyl1BefQQYaYS6WCSbIA'
+        });
+      };
+
+      strategy.userProfile = function userProfile(idToken, callback) {
+        if (idToken !== '9mlyl1BefQQYaYS6WCSbIA') {
+          return callback(new Error('Incorrect idToken'));
+        }
+
+        return callback(null, {});
+      };
+
+
+      let user;
+
+
+      let info;
+
+      before((done) => {
+        chai.passport.use(strategy)
+          .success((u, i) => {
+            user = u;
+            info = i;
+            done();
+          })
+          .req((req) => {
+            req.query = {};
+            req.query.code = 'SplxlOBeZQQYbYS6WxSbIA';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', () => {
+        expect(user).to.be.an('object');
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', () => {
+        expect(info).to.be.an('object');
+        expect(info.message).to.equal('Hello');
+      });
+    }); // that was approved using verify callback that accepts params, in passReqToCallback mode
+
     describe('that fails due to verify callback supplying false', () => {
       const strategy = new OAuth2Strategy({
         authorizationURL: 'https://www.example.com/oauth2/authorize',


### PR DESCRIPTION
** READ THIS FIRST! **

#### Is this a security patch?

If you discover a security issue please create an issue stating you've discovered a security
issue but don't divulge the issue, one of the maintainers will respond with an email address
you can send the details to. Once the issue has been patched the details can be made public.

<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [ X ] I have read the [CONTRIBUTING](https://github.com/passport-next/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ X ] I have added test cases which verify the correct operation of this feature or patch.
- [  ] I have added documentation pertaining to this feature or patch.
- [ X ] The automated test suite (`$ make test`) executes successfully.
- [ X ] The automated code linting (`$ npm run-script lint`) executes successfully.

<hr />

I was implementing this to create a new strategy for Twitch authentication on the new API. The response on authentication includes an id_token param (which is a JWT) from which the user's profile may be parsed. So I added an option parseIdToken for Strategy which decides whether the overloadable userProfile receives an access token or an id token.

Not sure what documentation I should add for this. Please let me know if anything is missing.